### PR TITLE
Ensure that the time is always on display

### DIFF
--- a/lib/Clocking.py
+++ b/lib/Clocking.py
@@ -148,7 +148,8 @@ class Clocking:
         _logger.debug('Clocking')
 
         self.get_messages()
-
+        self.minutes = 100 # ensure that the time is allways displayed on calling
+        
         while not (self.card == self.Odoo.adm):
 
             if self.checkodoo_wifi: # odoo connected and wifi strength


### PR DESCRIPTION
Avoid a "black screen" when you come back from the "admin menu" on the terminal